### PR TITLE
Simpler typeid

### DIFF
--- a/simpleecs/core.py
+++ b/simpleecs/core.py
@@ -170,7 +170,10 @@ class ECSManager():
         components = {k: [] for k in component_types}
         for entity in self.entities | self._dead_entities:
             for typeid in component_types:
-                components[typeid] += getattr(entity, component_list).get(typeid, [])
+                entity_components = getattr(entity, component_list)
+                matching_types = [t for t in entity_components.keys() if issubclass(t, typeid)]
+                for matching_type in matching_types:
+                    components[typeid] += entity_components.get(matching_type, [])
 
         return components
 

--- a/tests/test_simpleecs.py
+++ b/tests/test_simpleecs.py
@@ -11,7 +11,7 @@ def manager():
     return simpleecs.ECSManager()
 
 
-@simpleecs.Component('COUNT')
+@simpleecs.Component()
 class CountComponent:
     name: str
 
@@ -19,14 +19,14 @@ class CountComponent:
 class CountingSystem:
     num_components = 0
     component_types = [
-        'COUNT',
+        CountComponent,
     ]
     def init_components(self, components):
-        for _ in components['COUNT']:
+        for _ in components[CountComponent]:
             self.num_components += 1
 
     def destroy_components(self, components):
-        for _ in components['COUNT']:
+        for _ in components[CountComponent]:
             self.num_components -= 1
 
     def update(self, _dt, _components):
@@ -48,7 +48,7 @@ def test_update(manager):
 def test_system_init_destroy_components(manager):
     counting_system = CountingSystem()
     entity = manager.create_entity()
-    entity.add_component(CountComponent('foo'))
+    entity.add_component(CountComponent(name='foo'))
     manager.add_system(counting_system)
 
     assert counting_system.num_components == 0

--- a/tests/test_simpleecs.py
+++ b/tests/test_simpleecs.py
@@ -16,6 +16,10 @@ class CountComponent:
     name: str
 
 
+class DerivedCountComponent(CountComponent):
+    pass
+
+
 class CountingSystem:
     num_components = 0
     component_types = [
@@ -63,3 +67,15 @@ def test_system_init_destroy_components(manager):
 
     manager.update(0)
     assert counting_system.num_components == 0
+
+
+def test_pick_up_derived_components(manager):
+    counting_system = CountingSystem()
+    entity = manager.create_entity()
+    entity.add_component(DerivedCountComponent(name='foo'))
+    manager.add_system(counting_system)
+
+    assert counting_system.num_components == 0
+
+    manager.update(0)
+    assert counting_system.num_components == 1


### PR DESCRIPTION
Instead of using strings to identify component types, which could clash, just use the classes of components.